### PR TITLE
fix: avoid unnecessary empty lines if license header has leading/trailing \n

### DIFF
--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -27,15 +27,6 @@ import (
 	"strings"
 )
 
-func removeEmptyLinesAtStart(content string) string {
-	for i, line := range strings.Split(strings.TrimSuffix(content, "\n"), "\n") {
-		if len(line) > 0 {
-			return content[i:]
-		}
-	}
-	return ""
-}
-
 // ContainsLicense returns true if the content contains the words license or copyright in a header comment
 func ContainsLicense(content string) bool {
 	header := strings.ToLower(Extract(content))
@@ -60,12 +51,12 @@ func Extract(content string) (header string) {
 func Remove(content string) string {
 	header := Extract(content)
 	body := strings.ReplaceAll(content, header, "")
-	return removeEmptyLinesAtStart(body)
+	return strings.TrimSpace(body)
 }
 
-// Insert inserts the provided header at the beginning of the content
+// Insert inserts the provided header at the beginning of the content separated by one empty line (trims both content and header)
 func Insert(content, header string) string {
-	return header + "\n\n" + content
+	return strings.TrimSpace(header) + "\n\n" + strings.TrimSpace(content)
 }
 
 // Replace removes the current header and inserts the provided one

--- a/internal/header/header_test.go
+++ b/internal/header/header_test.go
@@ -69,10 +69,3 @@ func TestReplaceHeader(t *testing.T) {
 	output := Replace(input, header)
 	assert.True(t, output == expected)
 }
-
-func TestRemoveEmptyLinesAtStart(t *testing.T) {
-	expected := "line 1\n\nline 2"
-	input := "\n\n\nline 1\n\nline 2"
-	output := removeEmptyLinesAtStart(input)
-	assert.True(t, output == expected)
-}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -157,7 +157,7 @@ func File(path string, license string, options *config.Options) (Operation, erro
 
 	content := string(data)
 
-	if strings.Contains(content, license) {
+	if strings.Contains(content, strings.TrimSpace(license)) {
 		if options.Verbose {
 			fmt.Printf(" · %s => %s", path, okRender("License ok\n"))
 		}


### PR DESCRIPTION
Fixes #13 