### PR TITLE
fix: do not trim new lines at the end of the file when adding/replacing license

### DIFF
--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -47,16 +47,16 @@ func Extract(content string) (header string) {
 	return ""
 }
 
-// Remove removes the header from the content as well as potential empty lines between the header and body
+// Remove removes the header from the content as well as potential empty lines between the header and the body
 func Remove(content string) string {
 	header := Extract(content)
 	body := strings.ReplaceAll(content, header, "")
-	return strings.TrimSpace(body)
+	return strings.TrimLeft(body, "\n")
 }
 
-// Insert inserts the provided header at the beginning of the content separated by one empty line (trims both content and header)
+// Insert inserts the provided header at the beginning of the content separated by one empty line
 func Insert(content, header string) string {
-	return strings.TrimSpace(header) + "\n\n" + strings.TrimSpace(content)
+	return strings.TrimSpace(header) + "\n\n" + strings.TrimLeft(content, "\n")
 }
 
 // Replace removes the current header and inserts the provided one

--- a/internal/header/header_test.go
+++ b/internal/header/header_test.go
@@ -24,6 +24,7 @@ SOFTWARE.
 package header
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,7 +37,7 @@ func TestContainsLicense(t *testing.T) {
 }
 
 func TestExtractHeader(t *testing.T) {
-	expected := fakeTargetLicenseHeader()
+	expected := strings.TrimSpace(fakeTargetLicenseHeader())
 	input := fakeFileWithTargetLicenseHeader()
 	output := Extract(input)
 	assert.True(t, output == expected)

--- a/internal/header/header_test_data.go
+++ b/internal/header/header_test_data.go
@@ -33,7 +33,8 @@ const server = http.createServer((req, res) => {
 res.statusCode = 200;
 res.setHeader('Content-Type', 'text/plain');
 res.end('Hello World');
-});`
+});
+`
 }
 
 func fakeTargetLicenseHeader() string {
@@ -52,7 +53,8 @@ func fakeTargetLicenseHeader() string {
 *
 * You should have received a copy of the GNU General Public License
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
-*/`
+*/
+`
 }
 
 func fakeFileWithTargetLicenseHeader() string {
@@ -82,7 +84,8 @@ const server = http.createServer((req, res) => {
 res.statusCode = 200;
 res.setHeader('Content-Type', 'text/plain');
 res.end('Hello World');
-});`
+});
+`
 }
 
 func fakeFileWithDifferentLicenseHeader() string {
@@ -119,5 +122,6 @@ const server = http.createServer((req, res) => {
 res.statusCode = 200;
 res.setHeader('Content-Type', 'text/plain');
 res.end('Hello World');
-});`
+});
+`
 }


### PR DESCRIPTION
#19  For some teams, removing the empty line at the end of the file is annoying as it is marked by the linter as an issue.