### PR TITLE
feat: accept paths as an argument to -i flag (on top of folder and file name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 
 Command line utility written in [Go](https://golang.org) to **check** whether the **license headers** are included in the **source files** of a project.
 
-Optionally, the tool can **insert** the license in case it does not exist as well as **replace** it in case it is obsolete.
+Optionally, the tool can **insert** the license to a file in case it does not exist as well as **replace** it in case it is obsolete.
+
+The recommendation is to use the tool directly in the root folder of the project as only the files that match the provided **extensions** will be analyzed. Furthermore, there is the possibility to **ignore specific files and folders** if necessary by providing the `-i` flag.
+
+The tool expects the software license to be in a **block comment at the beginning of the file** following the format `/*  */`. 
+
+Thus, while it does support the source files of languages like *Go, Rust, JavaScript, TypeScript, C, C++, Java, Swift, Kotlin and C#*, it does not support the file extensions that do not use this style.
 
 ## Usage
 
@@ -15,6 +21,8 @@ Syntax:
 ```bash
 $ license-header-checker [-a] [-r] [-v] [-i path1,path2...] license-header-path src-path extensions...
 ```
+
+
 
 Options:
 

--- a/README.md
+++ b/README.md
@@ -4,30 +4,16 @@
 
 ![Demo](demo/demo.gif)
 
-Command line utility written in [Go](https://golang.org) to **check** whether the **license headers** are included in all files of a specific project folder that match a specific list of extensions.
+Command line utility written in [Go](https://golang.org) to **check** whether the **license headers** are included in the **source files** of a project.
 
-It can also **insert** the license in case it does not exist as well as **replace** wrong/old ones.
-
-## Compiling from source
-
-Requires [go 1.13](https://golang.org/doc/devel/release.html#go1.13) and make. To **build & test** the project:
-
-```bash
-$ make
-```
-
-To generate the **binaries for Windows, mac OS and linux**:
-
-```bash
-$ make cross-build
-```
+Optionally, the tool can **insert** the license in case it does not exist as well as **replace** it in case it is obsolete.
 
 ## Usage
 
-Synopsis:
+Syntax:
 
 ```bash
-$ license-header-checker [-a] [-r] [-v] [-i dir1,...] license-path project-path extensions...
+$ license-header-checker [-a] [-r] [-v] [-i dir1,dir2,file1,path1...] license-header-path project-path extensions...
 ```
 
 Options:
@@ -36,12 +22,50 @@ Options:
   -a        Add the target license in case the file does not have any.
   -r        Replace the existing license by the target one in case they are different.
   -v        Be verbose during execution.
-  -i        A comma separated list of the folders/files that should be ignored.
+  -i        A comma separated list of the folders/files/paths that should be ignored. 
+	        It does not support wildcards.
   -version  Display version number.
 ```
 
 Example:
 
 ```bash
-$ license-header-checker -v -a -r -i docs ../license_header.txt . js ts
+$ license-header-checker -v -a -r -i node_modules,myFile.js,client/assets ../license_header.txt . js ts
+```
+
+## Installation
+
+
+### Binary packages
+
+The binary packages for Linux, Windows and macOS are uploaded for each [release](https://github.com/lsm-dev/license-header-checker/releases).
+
+
+
+### Building from source
+
+Requires [go 1.13](https://golang.org/doc/devel/release.html#go1.13) and `make`.
+
+To **build**:
+
+```bash
+$ make build
+```
+
+To execute **unit tests**:
+
+```bash
+$ make test
+```
+
+To **install** in go/bin:
+
+```bash
+$ make install
+```
+
+To **cross-compile** (generate the binaries for Linux, Windows and macOS):
+
+```bash
+$ make cross-build
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Optionally, the tool can **insert** the license in case it does not exist as wel
 Syntax:
 
 ```bash
-$ license-header-checker [-a] [-r] [-v] [-i dir1,dir2,file1,path1...] license-header-path project-path extensions...
+$ license-header-checker [-a] [-r] [-v] [-i path1,path2...] license-header-path src-path extensions...
 ```
 
 Options:
@@ -23,14 +23,14 @@ Options:
   -r        Replace the existing license by the target one in case they are different.
   -v        Be verbose during execution.
   -i        A comma separated list of the folders, files and/or paths that should be ignored. 
-	        It does not support wildcards.
+            It does not support wildcards.
   -version  Display version number.
 ```
 
 Example:
 
 ```bash
-$ license-header-checker -v -a -r -i node_modules,myFile.js,client/assets ../license_header.txt . js ts
+$ license-header-checker -v -a -r -i node_modules,file.js,client/assets ../license_header.txt . js ts
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Options:
   -a        Add the target license in case the file does not have any.
   -r        Replace the existing license by the target one in case they are different.
   -v        Be verbose during execution.
-  -i        A comma separated list of the folders/files/paths that should be ignored. 
+  -i        A comma separated list of the folders, files and/or paths that should be ignored. 
 	        It does not support wildcards.
   -version  Display version number.
 ```

--- a/cmd/license-header-checker/main.go
+++ b/cmd/license-header-checker/main.go
@@ -34,7 +34,7 @@ import (
 
 func main() {
 	options := config.ParseOptions()
-	printIntro()
+	printIntro(options)
 	stats, err := process.Files(options)
 	if err != nil {
 		fmt.Println(errorRender(err))
@@ -51,8 +51,10 @@ var (
 	errorRender   = color.FgRed.Render
 )
 
-func printIntro() {
-	fmt.Printf("\nFiles:\n")
+func printIntro(options *config.Options) {
+	if options.Verbose {
+		fmt.Printf("\nFiles:\n")
+	}
 }
 
 func printOptions(options *config.Options) {

--- a/cmd/license-header-checker/main.go
+++ b/cmd/license-header-checker/main.go
@@ -52,7 +52,6 @@ var (
 
 func printIntro(options *config.Options) {
 	if options.Verbose {
-
 		fmt.Printf("Options: ")
 		fmt.Printf("\n · Project path: %s\n", infoRender(fmt.Sprintf("%s", options.Path)))
 		fmt.Printf(" · Ignore folders: %s\n", infoRender(fmt.Sprintf("%v", options.IgnorePaths)))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,7 @@ func ParseOptions() *Options {
 
 	writeFlagPtr := flag.Bool("a", false, "Add the target license in case the file does not have any.")
 	overwriteFlagPtr := flag.Bool("r", false, "Replace the existing license by the target one in case they are different.")
-	ignorePathsFlagPtr := flag.String("i", "", "A comma separated list of the folders/files/paths that should be ignored. Does not support wildcards.")
+	ignorePathsFlagPtr := flag.String("i", "", "A comma separated list of the folders, files and/or paths that should be ignored. Does not support wildcards.")
 	verboseFlagPtr := flag.Bool("v", false, "Be verbose during execution printing options, files being processed, execution time, ...")
 	versionFlagPtr := flag.Bool("version", false, "Display version number")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,7 @@ func ParseOptions() *Options {
 
 	writeFlagPtr := flag.Bool("a", false, "Add the target license in case the file does not have any.")
 	overwriteFlagPtr := flag.Bool("r", false, "Replace the existing license by the target one in case they are different.")
-	ignorePathsFlagPtr := flag.String("i", "", "A comma separated list of the folders/files that should be ignored.")
+	ignorePathsFlagPtr := flag.String("i", "", "A comma separated list of the folders/files/paths that should be ignored. Does not support wildcards.")
 	verboseFlagPtr := flag.Bool("v", false, "Be verbose during execution printing options, files being processed, execution time, ...")
 	versionFlagPtr := flag.Bool("version", false, "Display version number")
 

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -43,15 +43,15 @@ func HasExtension(path string, extensions []string) bool {
 	return false
 }
 
-// ShouldIgnore returns true if the path matches any of the ignore strings
-func ShouldIgnore(path string, ignores []string) bool {
-	segments := strings.Split(path, string(os.PathSeparator))
-	for _, ignore := range ignores {
-		sub := strings.Split(ignore, string(os.PathSeparator))
-		size := len(sub)
-		last := len(segments) - size
-		for i := 0; i <= last; i++ {
-			if reflect.DeepEqual(segments[i:i+size], sub) {
+// ShouldIgnore returns true if the path matches any of the paths to ignore
+func ShouldIgnore(path string, ignorePaths []string) bool {
+	pathSegments := strings.Split(path, string(os.PathSeparator))
+	for _, ignorePath := range ignorePaths {
+		ignorePathSegments := strings.Split(ignorePath, string(os.PathSeparator))
+		size := len(ignorePathSegments)
+		lastSegment := len(pathSegments) - size
+		for i := 0; i <= lastSegment; i++ {
+			if reflect.DeepEqual(pathSegments[i:i+size], ignorePathSegments) {
 				return true
 			}
 		}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -45,8 +45,14 @@ func HasExtension(path string, extensions []string) bool {
 // ShouldIgnore returns true if the path matches any of the ignore strings
 func ShouldIgnore(path string, ignoreFolders []string) bool {
 	segments := strings.Split(path, string(os.PathSeparator))
-	for _, segment := range segments {
-		for _, ignore := range ignoreFolders {
+	for _, ignore := range ignoreFolders {
+		if strings.Contains(ignore, string(os.PathSeparator)) {
+			if strings.Contains(path, ignore) {
+				return true
+			}
+			continue
+		}
+		for _, segment := range segments {
 			if segment == ignore {
 				return true
 			}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -42,12 +42,33 @@ func HasExtension(path string, extensions []string) bool {
 	return false
 }
 
+// containsPath returns true if path contains ignorePath
+func containsPath(path, ignorePath string) bool {
+	idx := strings.Index(path, ignorePath)
+	if idx < 0 {
+		return false
+	}
+	if idx > 0 {
+		leading := path[:idx]
+		if !strings.HasSuffix(leading, string(os.PathSeparator)) {
+			return false
+		}
+	}
+	if len(path) > (idx + len(ignorePath)) {
+		trailing := path[idx+len(ignorePath):]
+		if !strings.HasPrefix(trailing, string(os.PathSeparator)) {
+			return false
+		}
+	}
+	return true
+}
+
 // ShouldIgnore returns true if the path matches any of the ignore strings
-func ShouldIgnore(path string, ignoreFolders []string) bool {
+func ShouldIgnore(path string, ignores []string) bool {
 	segments := strings.Split(path, string(os.PathSeparator))
-	for _, ignore := range ignoreFolders {
+	for _, ignore := range ignores {
 		if strings.Contains(ignore, string(os.PathSeparator)) {
-			if strings.Contains(path, ignore) {
+			if containsPath(path, ignore) {
 				return true
 			}
 			continue

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 )
 
@@ -42,39 +43,15 @@ func HasExtension(path string, extensions []string) bool {
 	return false
 }
 
-// containsPath returns true if path contains ignorePath
-func containsPath(path, ignorePath string) bool {
-	idx := strings.Index(path, ignorePath)
-	if idx < 0 {
-		return false
-	}
-	if idx > 0 {
-		leading := path[:idx]
-		if !strings.HasSuffix(leading, string(os.PathSeparator)) {
-			return false
-		}
-	}
-	if len(path) > (idx + len(ignorePath)) {
-		trailing := path[idx+len(ignorePath):]
-		if !strings.HasPrefix(trailing, string(os.PathSeparator)) {
-			return false
-		}
-	}
-	return true
-}
-
 // ShouldIgnore returns true if the path matches any of the ignore strings
 func ShouldIgnore(path string, ignores []string) bool {
 	segments := strings.Split(path, string(os.PathSeparator))
 	for _, ignore := range ignores {
-		if strings.Contains(ignore, string(os.PathSeparator)) {
-			if containsPath(path, ignore) {
-				return true
-			}
-			continue
-		}
-		for _, segment := range segments {
-			if segment == ignore {
+		sub := strings.Split(ignore, string(os.PathSeparator))
+		size := len(sub)
+		last := len(segments) - size
+		for i := 0; i <= last; i++ {
+			if reflect.DeepEqual(segments[i:i+size], sub) {
 				return true
 			}
 		}

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -38,18 +38,27 @@ func TestFileHasExtension(t *testing.T) {
 }
 
 func TestFileShouldIgnore(t *testing.T) {
-	ignore := []string{"node_modules", "test", "docs", "dont_like_this_file.py", "client/assets", "dashboard/public"}
-	assert.True(t, ShouldIgnore("node_modules/index.js", ignore))
-	assert.True(t, ShouldIgnore("test/my-test.cpp", ignore))
-	assert.True(t, ShouldIgnore("dont_like_this_file.py", ignore))
-	assert.True(t, ShouldIgnore("myapp/docs/index.html", ignore))
-	assert.False(t, ShouldIgnore("node_modules/index.js", []string{}))
-	assert.False(t, ShouldIgnore("node_modules/index.js", nil))
-	assert.False(t, ShouldIgnore("src/testQ/my-file.cpp", ignore))
-	assert.False(t, ShouldIgnore("src/TestData.java", ignore))
-	assert.False(t, ShouldIgnore("src/test.py", ignore))
-	assert.True(t, ShouldIgnore("dashboard/public/index.js", ignore))
-	assert.True(t, ShouldIgnore("client/assets/index.js", ignore))
-	assert.False(t, ShouldIgnore("webclient/assets/index.js", ignore))
-	assert.False(t, ShouldIgnore("dashboard/publicity/index.js", ignore))
+	// Folder name matches => TRUE
+	assert.True(t, ShouldIgnore("node_modules/index.js", []string{"node_modules"}))
+	assert.True(t, ShouldIgnore("src/test/fmt-test.cpp", []string{"test"}))
+	assert.True(t, ShouldIgnore("myapp/docs/index.html", []string{"docs"}))
+	// File name matches => TRUE
+	assert.True(t, ShouldIgnore("neural.py", []string{"neural.py"}))
+	assert.True(t, ShouldIgnore("cmd/license-header-checker/main.go", []string{"main.go"}))
+	// Empty and/or nil ignore folders => FALSE
+	assert.False(t, ShouldIgnore("src/utils/stringutils.c", []string{}))
+	assert.False(t, ShouldIgnore("src/utils/stringutils.h", nil))
+	// File path contains folder name but it is not a folder => FALSE
+	assert.False(t, ShouldIgnore("src/testQ/my-file.cpp", []string{"test"}))
+	assert.False(t, ShouldIgnore("src/TestData.java", []string{"test"}))
+	assert.False(t, ShouldIgnore("test.py", []string{"test"}))
+	// File path matches ignore path => TRUE
+	assert.True(t, ShouldIgnore("dashboard/public/index.js", []string{"dashboard/public"}))
+	assert.True(t, ShouldIgnore("client/assets/index.js", []string{"client/assets"}))
+	assert.True(t, ShouldIgnore("src/drivers/I2C.cpp", []string{"drivers/I2C.cpp"}))
+	// File path contains ignore path but it is not a real path => FALSE
+	assert.False(t, ShouldIgnore("dashboard/publicity/index.js", []string{"dashboard/public"}))
+	assert.False(t, ShouldIgnore("webclient/assets/index.js", []string{"client/assets"}))
+	assert.False(t, ShouldIgnore("mysrc/drivers/I2C.cpp", []string{"src/drivers/I2C.cpp"}))
+	assert.False(t, ShouldIgnore("src/drivers/I2C.cpp", []string{"/drivers/I2C"}))
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -37,28 +37,36 @@ func TestFileHasExtension(t *testing.T) {
 	assert.False(t, HasExtension("styles.css", extensions))
 }
 
-func TestFileShouldIgnore(t *testing.T) {
-	// Folder name matches => TRUE
+func TestFileShouldIgnoreFolder(t *testing.T) {
 	assert.True(t, ShouldIgnore("node_modules/index.js", []string{"node_modules"}))
 	assert.True(t, ShouldIgnore("src/test/fmt-test.cpp", []string{"test"}))
-	assert.True(t, ShouldIgnore("myapp/docs/index.html", []string{"docs"}))
-	// File name matches => TRUE
+	assert.False(t, ShouldIgnore("src/mytest/my-file.cpp", []string{"test"}))
+	assert.False(t, ShouldIgnore("src/testdata.py", []string{"test"}))
+}
+
+func TestFileShouldIgnoreFile(t *testing.T) {
 	assert.True(t, ShouldIgnore("neural.py", []string{"neural.py"}))
 	assert.True(t, ShouldIgnore("cmd/license-header-checker/main.go", []string{"main.go"}))
-	// Empty and/or nil ignore folders => FALSE
-	assert.False(t, ShouldIgnore("src/utils/stringutils.c", []string{}))
-	assert.False(t, ShouldIgnore("src/utils/stringutils.h", nil))
-	// File path contains folder name but it is not a folder => FALSE
-	assert.False(t, ShouldIgnore("src/testQ/my-file.cpp", []string{"test"}))
-	assert.False(t, ShouldIgnore("src/TestData.java", []string{"test"}))
-	assert.False(t, ShouldIgnore("test.py", []string{"test"}))
-	// File path matches ignore path => TRUE
+	assert.False(t, ShouldIgnore("neural.py", []string{"neural"}))
+	assert.False(t, ShouldIgnore("cmd/license-header-checker/main.go", []string{"main"}))
+}
+
+func TestFileShouldIgnorePath(t *testing.T) {
 	assert.True(t, ShouldIgnore("dashboard/public/index.js", []string{"dashboard/public"}))
-	assert.True(t, ShouldIgnore("client/assets/index.js", []string{"client/assets"}))
 	assert.True(t, ShouldIgnore("src/drivers/I2C.cpp", []string{"drivers/I2C.cpp"}))
-	// File path contains ignore path but it is not a real path => FALSE
 	assert.False(t, ShouldIgnore("dashboard/publicity/index.js", []string{"dashboard/public"}))
 	assert.False(t, ShouldIgnore("webclient/assets/index.js", []string{"client/assets"}))
 	assert.False(t, ShouldIgnore("mysrc/drivers/I2C.cpp", []string{"src/drivers/I2C.cpp"}))
 	assert.False(t, ShouldIgnore("src/drivers/I2C.cpp", []string{"/drivers/I2C"}))
+}
+
+func TestFileShouldIgnoreEmptyOrNil(t *testing.T) {
+	assert.False(t, ShouldIgnore("src/utils/stringutils.c", []string{}))
+	assert.False(t, ShouldIgnore("src/utils/stringutils.h", nil))
+}
+
+func TestFileShouldIgnoreUsesFullIgnoreList(t *testing.T) {
+	assert.True(t, ShouldIgnore("node_modules/index.js", []string{"node_modules", "docs", "test"}))
+	assert.True(t, ShouldIgnore("node_modules/index.js", []string{"docs", "node_modules", "test"}))
+	assert.True(t, ShouldIgnore("node_modules/index.js", []string{"docs", "test", "node_modules"}))
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -38,7 +38,7 @@ func TestFileHasExtension(t *testing.T) {
 }
 
 func TestFileShouldIgnore(t *testing.T) {
-	ignore := []string{"node_modules", "test", "docs", "dont_like_this_file.py"}
+	ignore := []string{"node_modules", "test", "docs", "dont_like_this_file.py", "client/assets", "dashboard/public"}
 	assert.True(t, ShouldIgnore("node_modules/index.js", ignore))
 	assert.True(t, ShouldIgnore("test/my-test.cpp", ignore))
 	assert.True(t, ShouldIgnore("dont_like_this_file.py", ignore))
@@ -48,5 +48,6 @@ func TestFileShouldIgnore(t *testing.T) {
 	assert.False(t, ShouldIgnore("src/testQ/my-file.cpp", ignore))
 	assert.False(t, ShouldIgnore("src/TestData.java", ignore))
 	assert.False(t, ShouldIgnore("src/test.py", ignore))
-	assert.False(t, ShouldIgnore("README.md", ignore))
+	assert.True(t, ShouldIgnore("dashboard/public/index.js", ignore))
+	assert.True(t, ShouldIgnore("client/assets/index.js", ignore))
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -50,4 +50,6 @@ func TestFileShouldIgnore(t *testing.T) {
 	assert.False(t, ShouldIgnore("src/test.py", ignore))
 	assert.True(t, ShouldIgnore("dashboard/public/index.js", ignore))
 	assert.True(t, ShouldIgnore("client/assets/index.js", ignore))
+	assert.False(t, ShouldIgnore("webclient/assets/index.js", ignore))
+	assert.False(t, ShouldIgnore("dashboard/publicity/index.js", ignore))
 }

--- a/internal/header/header_test.go
+++ b/internal/header/header_test.go
@@ -41,6 +41,11 @@ func TestExtractHeader(t *testing.T) {
 	input := fakeFileWithTargetLicenseHeader()
 	output := Extract(input)
 	assert.True(t, output == expected)
+
+	expected = "/* copyright */"
+	input = "/* copyright */\nlorem ipsum dolor sit amet"
+	output = Extract(input)
+	assert.True(t, output == expected)
 }
 
 func TestRemoveHeader(t *testing.T) {


### PR DESCRIPTION
This PR implements feature #21 asked by @ericzon . 

The -i flag currently accepts a comma separated list of file/folder names.

Now it will be possible to provide paths too. It is backwards compatible with the previous solution.