### PR TITLE
feat: move options after process ends

### DIFF
--- a/cmd/license-header-checker/main.go
+++ b/cmd/license-header-checker/main.go
@@ -34,6 +34,7 @@ import (
 
 func main() {
 	options := config.ParseOptions()
+	printIntro()
 	stats, err := process.Files(options)
 	if err != nil {
 		fmt.Println(errorRender(err))
@@ -50,6 +51,10 @@ var (
 	errorRender   = color.FgRed.Render
 )
 
+func printIntro() {
+	fmt.Printf("\nFiles:\n")
+}
+
 func printOptions(options *config.Options) {
 	if options.Verbose {
 
@@ -65,7 +70,6 @@ func printOptions(options *config.Options) {
 			fmt.Printf("%s ", infoRender("replace"))
 		}
 		fmt.Printf("\n · License header: %s\n", infoRender(fmt.Sprintf("%s", options.LicensePath)))
-		fmt.Printf("\nFiles:\n")
 	}
 }
 

--- a/cmd/license-header-checker/main.go
+++ b/cmd/license-header-checker/main.go
@@ -34,12 +34,12 @@ import (
 
 func main() {
 	options := config.ParseOptions()
-	printIntro(options)
 	stats, err := process.Files(options)
 	if err != nil {
 		fmt.Println(errorRender(err))
 		os.Exit(1)
 	}
+	printOptions(options)
 	printStats(stats, options)
 }
 
@@ -50,10 +50,10 @@ var (
 	errorRender   = color.FgRed.Render
 )
 
-func printIntro(options *config.Options) {
+func printOptions(options *config.Options) {
 	if options.Verbose {
 
-		fmt.Printf("Options: ")
+		fmt.Printf("\nOptions: ")
 		fmt.Printf("\n · Project path: %s\n", infoRender(fmt.Sprintf("%s", options.Path)))
 		fmt.Printf(" · Ignore folders: %s\n", infoRender(fmt.Sprintf("%v", options.IgnorePaths)))
 		fmt.Printf(" · Extensions: %s\n", infoRender(fmt.Sprintf("%v", options.Extensions)))


### PR DESCRIPTION
## Description
At this moment options are shown before starting the process. Updating several files, this information gets lost in the screen history. I think it's more useful putting this before stats:
Starting with:
![image](https://user-images.githubusercontent.com/1809508/75427491-e010c680-5946-11ea-9447-d2904a275296.png)
Ending with:
![image](https://user-images.githubusercontent.com/1809508/75427411-ba83bd00-5946-11ea-9338-c1473152ac0f.png)
