### PR TITLE
refactor: use channels and decouple printing from processing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,8 +1,9 @@
+
 name: Go
 on: [push]
 jobs:
   build:
-    name: Build
+    name: Build & Test
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.13
@@ -12,33 +13,7 @@ jobs:
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
-              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-              dep ensure
-          fi
       - name: Build
-        run: go build -v ./cmd/license-header-checker
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
-        id: go
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
-              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-              dep ensure
-          fi
+        run: make build
       - name: Test
-        run: go test -v ./...
+        run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
               dep ensure
           fi
       - name: Build
-        run: go build -v ./cmd/license-header-checker/main.go
+        run: go build -v ./cmd/license-header-checker
 
   test:
     name: Test

--- a/cmd/license-header-checker/main.go
+++ b/cmd/license-header-checker/main.go
@@ -27,78 +27,16 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gookit/color"
 	"github.com/lsm-dev/license-header-checker/internal/config"
 	"github.com/lsm-dev/license-header-checker/internal/process"
 )
 
 func main() {
 	options := config.ParseOptions()
-	printIntro(options)
 	stats, err := process.Files(options)
 	if err != nil {
-		fmt.Println(errorRender(err))
+		fmt.Println(err.Error())
 		os.Exit(1)
 	}
-	printOptions(options)
 	printStats(stats, options)
-}
-
-var (
-	okRender      = color.FgGreen.Render
-	infoRender    = color.FgBlue.Render
-	warningRender = color.FgYellow.Render
-	errorRender   = color.FgRed.Render
-)
-
-func printIntro(options *config.Options) {
-	if options.Verbose {
-		fmt.Printf("\nFiles:\n")
-	}
-}
-
-func printOptions(options *config.Options) {
-	if options.Verbose {
-		fmt.Printf("\nOptions: ")
-		fmt.Printf("\n · Project path: %s\n", infoRender(fmt.Sprintf("%s", options.Path)))
-		fmt.Printf(" · Ignore folders: %s\n", infoRender(fmt.Sprintf("%v", options.IgnorePaths)))
-		fmt.Printf(" · Extensions: %s\n", infoRender(fmt.Sprintf("%v", options.Extensions)))
-		fmt.Printf(" · Flags: ")
-		if options.Add {
-			fmt.Printf("%s ", infoRender("add"))
-		}
-		if options.Replace {
-			fmt.Printf("%s ", infoRender("replace"))
-		}
-		fmt.Printf("\n · License header: %s\n", infoRender(fmt.Sprintf("%s", options.LicensePath)))
-	}
-}
-
-func printStats(stats *process.Stats, options *config.Options) {
-	licensesOkStr := okRender(fmt.Sprintf("%d", stats.LicensesOk))
-	licensesReplacedStr := warningRender(fmt.Sprintf("%d", stats.LicensesReplaced))
-	licensesAddedStr := errorRender(fmt.Sprintf("%d", stats.LicensesAdded))
-
-	totalFiles := stats.TotalOperations()
-
-	if options.Verbose {
-		fmt.Printf("\nResults:\n")
-		fmt.Printf(" · Total files: %d\n", totalFiles)
-		fmt.Printf(" · OK licenses: %s\n", licensesOkStr)
-		fmt.Printf(" · Added licenses: %s\n", licensesAddedStr)
-		fmt.Printf(" · Replaced licenses: %s\n", licensesReplacedStr)
-		fmt.Printf(" · Processing time: %d ms\n", stats.ElapsedMs)
-	} else {
-		fmt.Printf("%d files => %s licenses ok, %s licenses replaced, %s licenses added\n", totalFiles, licensesOkStr, licensesReplacedStr, licensesAddedStr)
-	}
-
-	if stats.SkippedAdds > 0 {
-		color.Error.Printf("[!] %d files had no license but where not changed as the -a (add) option was not supplied.\n", stats.SkippedAdds)
-	}
-	if stats.SkippedReplaces > 0 {
-		color.Error.Printf("[!] %d files had a different license but where not changed as the -r (replace) option was not supplied.\n", stats.SkippedReplaces)
-	}
-	if stats.Errors > 0 {
-		color.Error.Printf("[!] There where %d errors.\n", stats.Errors)
-	}
 }

--- a/cmd/license-header-checker/print.go
+++ b/cmd/license-header-checker/print.go
@@ -1,0 +1,177 @@
+/* MIT License
+
+Copyright (c) 2020 Lluis Sanchez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/gookit/color"
+	"github.com/lsm-dev/license-header-checker/internal/config"
+	"github.com/lsm-dev/license-header-checker/internal/process"
+)
+
+var (
+	okRender      = color.FgGreen.Render
+	infoRender    = color.FgBlue.Render
+	warningRender = color.FgYellow.Render
+	errorRender   = color.FgRed.Render
+)
+
+// printStats prints the options, files processed and aggregate data
+func printStats(stats *process.Stats, options *config.Options) {
+	var licensesOk, licensesAdded, licensesReplaced, skippedAdds, skippedReplaces, errors []string
+
+	for _, op := range stats.Operations {
+		action := op.Action
+		switch action {
+		case process.SkippedAdd:
+			skippedAdds = append(skippedAdds, op.Path)
+		case process.SkippedReplace:
+			skippedReplaces = append(skippedReplaces, op.Path)
+		case process.LicenseOk:
+			licensesOk = append(licensesOk, op.Path)
+		case process.LicenseAdded:
+			licensesAdded = append(licensesAdded, op.Path)
+		case process.LicenseReplaced:
+			licensesReplaced = append(licensesReplaced, op.Path)
+		case process.OperationError:
+			errors = append(errors, op.Path)
+		}
+	}
+
+	if options.Verbose {
+		printFiles(licensesOk, licensesReplaced, licensesAdded, skippedReplaces, skippedAdds, errors)
+		printOptions(options)
+		printTotals(len(licensesOk), len(licensesReplaced), len(licensesAdded), len(skippedReplaces), len(skippedAdds), len(errors), int(stats.ElapsedMs))
+	} else {
+		fmt.Printf("%s licenses ok, %s licenses replaced, %s licenses added\n", okRender(fmt.Sprintf("%d", len(licensesOk))), warningRender(fmt.Sprintf("%d", len(licensesReplaced))), errorRender(fmt.Sprintf("%d", len(licensesAdded))))
+	}
+
+	printWarnings(len(skippedReplaces), len(skippedAdds), len(errors))
+}
+
+// printFiles prints the the output of each file grouped by result type
+func printFiles(licensesOk, licensesReplaced, licensesAdded, skippedReplaces, skippedAdds, errors []string) {
+	fmt.Printf("files:\n")
+	if len(licensesOk) > 0 {
+		fmt.Printf("  license_ok:\n")
+		for _, file := range licensesOk {
+			fmt.Printf("    - %s\n", okRender(fmt.Sprintf("%v", file)))
+		}
+	}
+	if len(licensesReplaced) > 0 {
+		fmt.Printf("  license_replaced:\n")
+		for _, file := range licensesReplaced {
+			fmt.Printf("    - %s\n", warningRender(fmt.Sprintf("%v", file)))
+		}
+	}
+	if len(licensesAdded) > 0 {
+		fmt.Printf("  license_added:\n")
+		for _, file := range licensesAdded {
+			fmt.Printf("    - %s\n", errorRender(fmt.Sprintf("%v", file)))
+		}
+	}
+	if len(skippedAdds) > 0 {
+		fmt.Printf("  skipped_add:\n")
+		for _, file := range skippedAdds {
+			fmt.Printf("    - %s\n", errorRender(fmt.Sprintf("%v", file)))
+		}
+	}
+	if len(skippedReplaces) > 0 {
+		fmt.Printf("  skipped_replace:\n")
+		for _, file := range skippedReplaces {
+			fmt.Printf("    - %s\n", errorRender(fmt.Sprintf("%v", file)))
+		}
+	}
+	if len(errors) > 0 {
+		fmt.Printf("  errors:\n")
+		for _, file := range errors {
+			fmt.Printf("    - %s\n", errorRender(fmt.Sprintf("%v", file)))
+		}
+	}
+}
+
+// printOptions prints the options that were supplied to the cli app
+func printOptions(options *config.Options) {
+	fmt.Printf("options:\n")
+	fmt.Printf("  project_path: %s\n", infoRender(fmt.Sprintf("%s", options.Path)))
+	if len(options.IgnorePaths) > 0 {
+		fmt.Printf("  ignore_paths:\n")
+		for _, ignorePaths := range options.IgnorePaths {
+			fmt.Printf("    - %s\n", infoRender(fmt.Sprintf("%v", ignorePaths)))
+		}
+	}
+	fmt.Printf("  extensions:\n")
+	for _, ext := range options.Extensions {
+		fmt.Printf("    - %s\n", infoRender(fmt.Sprintf("%v", ext)))
+	}
+	fmt.Printf("  flags:\n")
+	if options.Add {
+		fmt.Printf("    - %s\n", infoRender("add"))
+	}
+	if options.Replace {
+		fmt.Printf("    - %s\n", infoRender("replace"))
+	}
+	if options.Verbose {
+		fmt.Printf("    - %s\n", infoRender("verbose"))
+	}
+	fmt.Printf("  license_header: %s\n", infoRender(fmt.Sprintf("%s", options.LicensePath)))
+}
+
+// printTotals prints the aggregated data
+func printTotals(licensesOk, licensesReplaced, licensesAdded, skippedReplaces, skippedAdds, errors, elapsedMs int) {
+	fmt.Printf("totals:\n")
+	if licensesOk > 0 {
+		fmt.Printf("  license_ok: %s\n", okRender(fmt.Sprintf("%v files", licensesOk)))
+	}
+	if licensesReplaced > 0 {
+		fmt.Printf("  license_replaced: %s\n", warningRender(fmt.Sprintf("%v files", licensesReplaced)))
+	}
+	if licensesAdded > 0 {
+		fmt.Printf("  license_added: %s\n", errorRender(fmt.Sprintf("%v files", licensesAdded)))
+	}
+	if skippedAdds > 0 {
+		fmt.Printf("  skipped_add: %s\n", errorRender(fmt.Sprintf("%v files", skippedAdds)))
+	}
+	if skippedReplaces > 0 {
+		fmt.Printf("  skipped_replace: %s\n", errorRender(fmt.Sprintf("%v files", skippedReplaces)))
+	}
+	if errors > 0 {
+		fmt.Printf("  error: %s\n", errorRender(fmt.Sprintf("%v files", errors)))
+	}
+	fmt.Printf("  elapsed_time: %s\n", infoRender(fmt.Sprintf("%vms", elapsedMs)))
+}
+
+// printWarnings prints warnings to the user in case he/she may have forgotten to add -a or -r flag
+func printWarnings(skippedReplaces, skippedAdds, errors int) {
+	if skippedAdds > 0 {
+		color.Error.Printf("[!] %d files had no license but were not changed as the -a (add) option was not supplied.\n", skippedAdds)
+	}
+	if skippedReplaces > 0 {
+		color.Error.Printf("[!] %d files had a different license but were not changed as the -r (replace) option was not supplied.\n", skippedReplaces)
+	}
+	if errors > 0 {
+		color.Error.Printf("[!] There where %d errors.\n", errors)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,8 @@ type Options struct {
 // ParseOptions returns the parsed options from cli
 func ParseOptions() *Options {
 
-	writeFlagPtr := flag.Bool("a", false, "Add the target license in case the file does not have any.")
-	overwriteFlagPtr := flag.Bool("r", false, "Replace the existing license by the target one in case they are different.")
+	addFlagPtr := flag.Bool("a", false, "Add the target license in case the file does not have any.")
+	replaceFlagPtr := flag.Bool("r", false, "Replace the existing license by the target one in case they are different.")
 	ignorePathsFlagPtr := flag.String("i", "", "A comma separated list of the folders, files and/or paths that should be ignored. Does not support wildcards.")
 	verboseFlagPtr := flag.Bool("v", false, "Be verbose during execution printing options, files being processed, execution time, ...")
 	versionFlagPtr := flag.Bool("version", false, "Display version number")
@@ -67,18 +67,26 @@ func ParseOptions() *Options {
 
 	licensePath := args[0]
 	path := args[1]
+
 	extensions := []string{}
 	for _, e := range args[2:] {
 		extensions = append(extensions, "."+e)
 	}
 
+	ignorePaths := []string{}
+	for _, p := range strings.Split(*ignorePathsFlagPtr, ",") {
+		if len(p) > 0 {
+			ignorePaths = append(ignorePaths, p)
+		}
+	}
+
 	return &Options{
-		*writeFlagPtr,
-		*overwriteFlagPtr,
+		*addFlagPtr,
+		*replaceFlagPtr,
 		*verboseFlagPtr,
 		path,
 		licensePath,
 		extensions,
-		strings.Split(*ignorePathsFlagPtr, ","),
+		ignorePaths,
 	}
 }

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -60,13 +60,13 @@ func ShouldIgnore(path string, ignorePaths []string) bool {
 }
 
 // Replace remove the file and create a new one with the specified content
-func Replace(path string, content string) error {
-	err := os.Remove(path)
+func Replace(filePath string, content string) error {
+	err := os.Remove(filePath)
 	if err != nil {
 		return fmt.Errorf("failed deleting the file: %w", err)
 	}
 
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("failed opening file: %w", err)
 	}


### PR DESCRIPTION
General refactor:
- Fix issue introduced by previous feature: if no -i flag was supplied, the tool would ignore all files.
- Use of channels instead of waiting group + atomic variables.
- Decouple printing from the processing.
- Enhanced printing in yaml format.